### PR TITLE
Add link where the guide was calling for one.

### DIFF
--- a/01-Introduction.Rmd
+++ b/01-Introduction.Rmd
@@ -2,7 +2,7 @@
 
 This guide is heavily influenced by the [Python Developer Guide](https://devguide.python.org/), and is a comprehensive resource for contributing to R Core – for both new and experienced contributors. It is maintained by the [R Contribution Working Group](/working-group). We welcome your contributions to R Core!
 
-## How to contribute to this guide? {-}
+## How to contribute to this guide? {#how-to-contribute-to-this-guide -}
 
 This guide is built using bookdown which makes editing it easier, provided you have a GitHub account (sign-up at [github.com](https://github.com/)). After you log-in to GitHub, click on the ‘Edit’ icon highlighted with a red ellipse in the image below. This will take you to an editable version of the the source R Markdown file that generated the page you are on:
 

--- a/07-documenting_R.Rmd
+++ b/07-documenting_R.Rmd
@@ -94,7 +94,7 @@ If you decide to proofread, read a section of the documentation from start to fi
 
 The Developer’s Guide (what you are reading now) uses the same process as the main R documentation, except for some small differences. The source lives in a [GitHub repository](https://github.com/forwards/rdevguide) and bug reports should be submitted to the [devguide GitHub tracker](https://github.com/forwards/rdevguide/issues).
 
-Our dev guide workflow uses continuous integration and deployment so changes to the dev guide are normally published when the pull request is merged. (Link to how-to-contribute from the introduction chapter)
+Our dev guide workflow uses continuous integration and deployment so changes to the dev guide are normally published when the pull request is merged. [How to contribute to this guide from the introduction.](#how-to-contribute-to-this-guide)
 
 ## Instructions for reporting the CRAN policy bugs -- discussion in slack (random channel)
 


### PR DESCRIPTION
This change maintains the effect of {-} for the header as well as being able to link to it.