### PR TITLE
Simplify list of prerequisites for Ubuntu and Fedora

### DIFF
--- a/02-getting_started.Rmd
+++ b/02-getting_started.Rmd
@@ -35,103 +35,38 @@ If you need to install svn you can use your distribution's package manager to in
 
 ### Ubuntu
 
-In Ubuntu you can use :
-
-<!-- # Command to obtain it: apt-rdepends --build-depends --follow=DEPENDS r-base | grep " B" | sed -e "s/ Build-Depends: //" | sort -->
+In Ubuntu you can use this command to find all the dependencies of R:
 
 ```sh
-sudo apt-get install -y \
-      bash-completion \
-      bison \
-      debhelper-compat \
-      default-jdk \
-      g++ \
-      gcc \
-      gfortran \
-      groff-base \
-      libblas-dev \
-      libbz2-dev \
-      libcairo2-dev \
-      libcurl4-dev \
-      libcurl4-openssl-dev \
-      libjpeg-dev \
-      liblapack-dev \
-      liblzma-dev \
-      libncurses5-dev \
-      libpango1.0-dev \
-      libpcre2-dev \
-      libpcre3-dev \
-      libpng-dev \
-      libreadline-dev \
-      libtiff5-dev \
-      libx11-dev \
-      libxt-dev \
-      mpack \
-      rsync \
-      tcl8.6-dev \
-      texinfo \
-      texlive-base \
-      texlive-extra-utils \
-      texlive-fonts-extra \
-      texlive-fonts-recommended \
-      texlive-latex-base \
-      texlive-latex-extra \
-      texlive-latex-recommended \
-      texlive-plain-generic \
-      tk8.6-dev \
-      x11proto-core-dev \
-      xauth \
-      xdg-utils \
-      xfonts-base \
-      xvfb \
-      zlib1g-dev 
+apt-rdepends --build-depends --follow=DEPENDS r-base-dev | grep " B" | sed -e "s/  Build-Depends: //"
+```
+
+It might require installation of apt-rdepends which can be done from default repositories via `sudo apt-get install apt-rdepends`.
+
+To install all the R dependencies you can use:
+
+```sh
+sudo apt-get build-dep r-base-dev
 ```
 
 ### Fedora
 
-<!-- # Command to obtain it: dnf rq -q --repo=fedora-source --requires R -->
-<!-- # Plus the rsync package-->
-
-In Fedora you can use:
+In Fedora you can use this command to find all the dependencies of R:
 
 ```sh
-sudo dnf install -y \
-    autoconf \
-    automake \
-    bzip2-devel \
-    cairo-devel \
-    flexiblas-devel \
-    gcc-c++ \
-    gcc-gfortran \
-    java-devel \
-    less \
-    libICE-devel \
-    libSM-devel \
-    libX11-devel \
-    libXmu-devel \
-    libXt-devel \
-    libcurl-devel \
-    libicu-devel \
-    libjpeg-devel \
-    libpng-devel \
-    libtiff-devel \
-    libtool \
-    ncurses-devel \
-    pango-devel \
-    pcre2-devel \
-    readline-devel \
-    rsync \
-    tcl-devel \
-    'tex(inconsolata.sty)' \
-    'tex(latex)' \
-    'tex(upquote.sty)' \
-    texinfo-tex \
-    tk-devel \
-    tre-devel \
-    valgrind-devel \
-    xz-devel \
-    zlib-devel
+dnf rq -q --repo=fedora-source --requires R 
 ```
+
+You will also need the rsync package to download the recommended packages. 
+
+To install them you can use:
+
+```sh
+dnf install 'dnf-command(builddep)'
+dnf install rsync
+dnf builddep R
+```
+
 
 ## Building R 
 


### PR DESCRIPTION
I added the command to find the list of prerequisites for Ubuntu and Fedora and also how to install them without installing R via the OS package manager.

The instructions for Windows and Linux match.
 - In linux there the configuration is done via "$TOP_SRCDIR/configure"  --enable-R-shlib but in windows it doesn't seem to be needed.
 - Both instructions end with `make check` and the optional `make check-devel` and `make check recommended`. It was commented to use `make check-all` but this might take too long.
 - The guide assumes that there is no previous attempt and the users starts from a clean state. But it might be nice to mention something about how to make sure it is a clean build. 
 - In windows I do not make any mention to Rstudio, perhaps I can add a mention that users should go and select which version of R want to use? (While for Linux users I could mention the RSTUIDO_WHICH_R variable to control that)

Currently the macOS section is empty, there is not even a "In progress" note. Should I document that? 

Let me know if I missed some other comments from the meeting, @hturner. 