### PR TITLE
Update instructions to use RTools43

### DIFF
--- a/02-getting_started.Rmd
+++ b/02-getting_started.Rmd
@@ -170,7 +170,7 @@ Daily binaries for `r-devel` are made available for [download and installation](
 Before installing R from source, some additional programs are needed, as per the [latest documentation](https://cran.r-project.org/bin/windows/base/howto-R-4.2.html):
 
 1.  [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is the suggested toolchain bundle for building R base and R packages containing compiled code on Windows. 
-  The latest [version of Rtools42](https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html) can be installed using the [Rtools installer rtools42-XXXX-XXX.exe ](https://cran.r-project.org/bin/windows/Rtools/rtools42/files/).
+  The latest [version of Rtools](https://cran.r-project.org/bin/windows/Rtools/rtools43/rtools.html) can be installed using the [Rtools installer rtools43-XXXX-XXX.exe ](https://cran.r-project.org/bin/windows/Rtools/rtools43/files/).
 
 2.  A LaTeX compiler is needed to install and build R, check packages and build  manuals. 
     On CRAN, MiKTeX is used, which can be downloaded from <https://miktex.org>. 


### PR DESCRIPTION
I replaced the links from rtools42 to rtools43, but I have not checked the installation in Windows.

It would be nice if there were a URL that we could always point that would be updated as new versions appear.
Something like a Latest version in https://cran.r-project.org/bin/windows/Rtools/. 
Internally I think it could be a dynamic link to the latest version which only needs to be updated as new RTools version are released. 
This would make the installation process probably more automated (scripts could use always the same link and donwload the file `rtools*`) at the risk of not reading the detailed documentation (as I did in this PR) and miss some instructions which could lead to confusion. 