### PR TITLE
Update 02-getting_started.Rmd

### DIFF
--- a/02-getting_started.Rmd
+++ b/02-getting_started.Rmd
@@ -263,7 +263,7 @@ Before installing R from source, some additional programs are needed, as per the
 
 ### macOS
 
-This section will be added after the official [installation instructions for macOS in the R installation and administration manual]([https://cran.r-project.org/doc/manuals/r-devel/R-admin.html](https://cran.r-project.org/doc/manuals/r-devel/R-admin.html#macOS) have been updated for R 4.3.0.
+This section will be added after the official [installation instructions for macOS in the R installation and administration manual](https://cran.r-project.org/doc/manuals/r-devel/R-admin.html#macOS) have been updated for R 4.3.0.
 
 
 ## See also

--- a/02-getting_started.Rmd
+++ b/02-getting_started.Rmd
@@ -211,8 +211,8 @@ Before installing R from source, some additional programs are needed, as per the
 3. Add gcc, MiKTeX and tar to the PATH and set one tar option:
 
     ```sh
-    export PATH=/x86_64-w64-mingw32.static.posix/bin:$PATH
-    export PATH=/c/Program\ Files/MiKTeX/miktex/bin/x64:$PATH
+    export PATH="/x86_64-w64-mingw32.static.posix/bin:$PATH"
+    export PATH="/c/Program Files/MiKTeX/miktex/bin/x64:$PATH"
     export TAR="/usr/bin/tar"
     export TAR_OPTIONS="--force-local"
     ```
@@ -220,7 +220,7 @@ Before installing R from source, some additional programs are needed, as per the
     If MiKTeX was installed just for your user you might need to run:
 
     ```sh
-    export PATH=/c/Users/$USER/AppData/Local/Programs/MiKTeX/miktex/bin/x64:$PATH
+    export PATH="/c/Users/$USER/AppData/Local/Programs/MiKTeX/miktex/bin/x64:$PATH"
     ```
    
 4. Check that all the programs can be found:

--- a/02-getting_started.Rmd
+++ b/02-getting_started.Rmd
@@ -204,15 +204,15 @@ Before installing R from source, some additional programs are needed, as per the
 
     ```sh
     cd "$TOP_SRCDIR"
-    wget -np -nd -r -l1 -A 'tcltk-*.zip' https://cran.r-project.org/bin/windows/Rtools/rtools42/files/
+    wget -np -nd -r -l1 -A 'tcltk-*.zip' https://cran.r-project.org/bin/windows/Rtools/rtools43/files/
     unzip "tcltk-*.zip"
     ```
 
 3. Add gcc, MiKTeX and tar to the PATH and set one tar option:
 
     ```sh
-    export PATH="/x86_64-w64-mingw32.static.posix/bin:$PATH"
-    export PATH="/c/Program\ Files/MiKTeX/miktex/bin/x64:$PATH"
+    export PATH=/x86_64-w64-mingw32.static.posix/bin:$PATH
+    export PATH=/c/Program\ Files/MiKTeX/miktex/bin/x64:$PATH
     export TAR="/usr/bin/tar"
     export TAR_OPTIONS="--force-local"
     ```
@@ -220,7 +220,7 @@ Before installing R from source, some additional programs are needed, as per the
     If MiKTeX was installed just for your user you might need to run:
 
     ```sh
-    export PATH="/c/Users/$USER/AppData/Local/Programs/MiKTeX/miktex/bin/x64:$PATH"
+    export PATH=/c/Users/$USER/AppData/Local/Programs/MiKTeX/miktex/bin/x64:$PATH
     ```
    
 4. Check that all the programs can be found:


### PR DESCRIPTION
Fixed:
- An instance of `rtools42` instead of the latest `rtools43`
- Remove inverted commas in paths for Windows build