### PR TITLE
add R manuals section and a table of manuals with nicknames

### DIFF
--- a/07-documenting_R.Rmd
+++ b/07-documenting_R.Rmd
@@ -74,6 +74,21 @@ The language used in the documentations should follow these basic rules:
 
 Extensive details of writing R documentation files can be found [here](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-R-documentation-files).
 
+## R manuals
+
+The [R manuals](https://cran.r-project.org/manuals.html) are a part of the [R sources](https://svn.r-project.org/R/trunk/doc/manual/). Hence, bug reports/patches can also be submitted via Bugzilla, e.g. [Bug 15221 - R-admin/'Installing R under Windows': Missing argument name](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=15221). Note that they are typically referred to by their file names some of which are listed below:
+
+| Manual | Nickname |
+| -- | -- |
+| An Introduction to R | "R-intro"  |
+| R Data Import/Export  | "R-data"  |
+| R Installation and Administration | "R-admin"  |
+| Writing R Extensions | "R-exts" |
+| The R language definition | "R-lang"  |
+| R Internals | "R-ints" | 
+
+The [Texinfo manual](https://www.gnu.org/software/texinfo/) should be referred to for [how to mark up text](https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html).
+
 ## Helping with documentation
 
 Maintaining the accuracy  of R's documentations and keeping a high level of quality takes a lot of effort. Community members, like you, help with writing, editing, and updating content, and these contributions are appreciated and welcomed.

--- a/07-documenting_R.Rmd
+++ b/07-documenting_R.Rmd
@@ -89,7 +89,8 @@ The [R manuals](https://cran.r-project.org/manuals.html) are a part of the [R so
 
 Note: 
 
-- Every manual is associated with a particular version of R, hence please consider the version of R when looking for the manuals.
+- Every manual is associated with a particular version of R, so you should check the version before reporting a bug.
+- The [R manuals](https://cran.r-project.org/manuals.html) page has links for the [three types of release](https://contributor.r-project.org/rdevguide/GetStart.html#the-r-source-code): `r-release`, `r-patched` and `r-devel`.  These nicknames appear in the URLs, e.g. https://cran.r-project.org/doc/manuals/r-release/R-intro.html.
 - The [Texinfo manual](https://www.gnu.org/software/texinfo/) should be referred to for [how to mark up text](https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html).
 
 ## Helping with documentation

--- a/07-documenting_R.Rmd
+++ b/07-documenting_R.Rmd
@@ -76,7 +76,7 @@ Extensive details of writing R documentation files can be found [here](https://c
 
 ## R manuals
 
-The [R manuals](https://cran.r-project.org/manuals.html) are a part of the [R sources](https://svn.r-project.org/R/trunk/doc/manual/). Hence, bug reports/patches can also be submitted via Bugzilla, e.g. [Bug 15221 - R-admin/'Installing R under Windows': Missing argument name](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=15221). Note that they are typically referred to by their file names some of which are listed below:
+The [R manuals](https://cran.r-project.org/manuals.html) are a part of the [R sources](https://svn.r-project.org/R/trunk/doc/manual/). Hence, bug reports/patches can also be submitted via Bugzilla, e.g. [Bug 15221 - R-admin/'Installing R under Windows': Missing argument name](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=15221). Note that they are typically referred to by their file names as listed below:
 
 | Manual | Nickname |
 | -- | -- |

--- a/07-documenting_R.Rmd
+++ b/07-documenting_R.Rmd
@@ -87,7 +87,10 @@ The [R manuals](https://cran.r-project.org/manuals.html) are a part of the [R so
 | The R language definition | "R-lang"  |
 | R Internals | "R-ints" | 
 
-The [Texinfo manual](https://www.gnu.org/software/texinfo/) should be referred to for [how to mark up text](https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html).
+Note: 
+
+- Every manual is associated with a particular version of R, hence please consider the version of R when looking for the manuals.
+- The [Texinfo manual](https://www.gnu.org/software/texinfo/) should be referred to for [how to mark up text](https://www.gnu.org/software/texinfo/manual/texinfo/texinfo.html).
 
 ## Helping with documentation
 


### PR DESCRIPTION
To make this guide more self-contained, it would be useful to describe any bug examples linked in the guide.
For example, instead of including the bug link as https://bugs.r-project.org/show_bug.cgi?id=15221 in a chapter, briefly describe the bug and use a hyperlink with a title of the linked bug: [Bug 15221 - R-admin/'Installing R under Windows': Missing argument name](https://bugs.r-project.org/show_bug.cgi?id=15221).