### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -11,7 +11,7 @@ jobs:
     name: Render-Book
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-tinytex@v2
@@ -39,7 +39,7 @@ jobs:
      - name: Checkout
        uses: actions/checkout@main
      - name: Download artifact
-       uses: actions/download-artifact@v1.0.0
+       uses: actions/download-artifact@v4
        with:
          # Artifact name
          name: docs # optional


### PR DESCRIPTION
## Overview

Quick change to update the actions for the rdevguide as I noticed one of the actions was failing.

## Details

https://github.com/r-devel/rdevguide/actions/runs/11049512047/job/30695306589

![image](https://github.com/user-attachments/assets/e5e6a78f-988f-4a6c-8527-f05a625202b3)

