### PR TITLE
Fix links from #187 and ignore .tex file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 docs/
 rdevguide.rds
 rdevguide.log
+rdevguide.tex
 
 # temp files
 *~

--- a/01-Introduction.Rmd
+++ b/01-Introduction.Rmd
@@ -6,7 +6,7 @@ This guide is a comprehensive resource for contributing to base R^[The [set of p
 
 Contributions to base R are possible in a number of different ways. Some of them are listed below:
 
-1. Contributing to bug fixing: Refer [Bug Tracking](#BugTrack) and [Reviewing Bugs](#ReviewBugs).
+1. Contributing to bug fixing: Refer [Issue Tracking](#IssueTrack) and [Reviewing Bugs](#ReviewBugs).
 2. Contributing to translations: Refer [Translations](#).
 3. Testing R before release: Refer [Testing Pre-release R Versions](#TestRVer).
 
@@ -22,7 +22,7 @@ The guide is intended as a comprehensive resource for contributing to base R. Th
 
 <!-- TODO(Saranjeet): Add other operating systems as they get included in the guide-->
 
-2. The [Bug Tracking](#BugTrack) and the [Reviewing Bugs](#ReviewBugs) chapters discuss how to find bugs in R and how to review bug reports that are submitted to Bugzilla.
+2. The [Issue Tracking](#IssueTrack) and the [Reviewing Bugs](#ReviewBugs) chapters discuss how to find bugs in R and how to review bug reports that are submitted to Bugzilla.
 
 3. The [Finding the Source](#FindSource) chapter provides an overview of the R codebase and helps with finding source code of base functions written in R and/or C.
 

--- a/08-lifecycle_of_a_Patch.Rmd
+++ b/08-lifecycle_of_a_Patch.Rmd
@@ -40,7 +40,7 @@ Then you should check that R still works as expected via:
   make check-devel
   ```
 
-If there is no test for your proposed change you can add a new regression test, following [the guidelines](#TestR).
+If there is no test for your proposed change you can add a new regression test, following [the guidelines](#TestRVer).
 
 Then you should bring changes from the repository into the working copy, in case any other change has been introduced, and create a patch.diff file with just the changes you want to propose to the R core:
 

--- a/15-developer_tools.Rmd
+++ b/15-developer_tools.Rmd
@@ -4,7 +4,7 @@ This chapter lists resources and tools which R developers may use. Here we will 
 
 ## Subversion (svn) client
 
-Subversion (svn) is a version control system that tracks any changes made to files and directories. You can install either the TortoiseSVN (https://tortoisesvn.net/, command line tool, and Windows Explorer integration) or the SlikSVN (https://sliksvn.com/download/, just the command line tool) client. They have Windows installers and can be used from Windows cmd or RStudio terminal.
+Subversion (svn) is a version control system that tracks any changes made to files and directories. You can install either the [TortoiseSVN](https://tortoisesvn.net/) (command line tool, and Windows Explorer integration) or the [SlikSVN](https://sliksvn.com/download/) (just the command line tool) client. They have Windows installers and can be used from Windows cmd or RStudio terminal.
 
 Some resources for learning subversion commands:
 


### PR DESCRIPTION
New version of #187 - as it's small changes we decided it'd be easier to copy over to a new branch than fix up the conflicts with the previous branch being out of date. Copied the description across below:

## Overview

Quick one to correct a couple of broken links I noticed in the console messages, and also to ignore files that are created when you build the site.

## Notes for reviewers

### links

I'm not 100% sure on the original intention for the BugTrack link as I couldn't see a bug tracking page. I've guessed that the Issue Tracking page makes the most sense to point to, though there is also the Reporting Bugs page that could have been pointed to instead.

There is one broken link still left after this and #186. The blank link on page 11 that looks like it's meant to show the affiliations of R Core members, I couldn't easily find what this should be linking to so left it as it was for now.

### .gitignore

I've been using Windows when building - I don't know if tinytex behaves any differently on Mac or Linux. It seemed safe to ignore the .log file that's generated on any build, and then the .tex file looks like something tinytex normally cleans up itself, but might have been left lingering around, so deleted then ignored that file too, saves any potential confusion for new contributors having additional files appearing in their Git changes.