### PR TITLE
split current and former members to separate lists and update for 2024

### DIFF
--- a/12-R_Core_Developers.Rmd
+++ b/12-R_Core_Developers.Rmd
@@ -8,7 +8,7 @@ Current members of the R Core team:
   * [Peter Dalgaard](www.cbs.dk/en/staff/pdmes)
   * [Robert Gentleman](https://en.wikipedia.org/wiki/Robert_Gentleman_(statistician))
   * [Kurt Hornik](https://statmath.wu.ac.at/~hornik/software.html)
-  * [Ross Ihaka](https://www.researchgate.net/profile/Ross-Ihaka)
+  * [Ross Ihaka](https://en.wikipedia.org/wiki/Ross_Ihaka)
   * [Tomas Kalibera](https://github.com/kalibera)
   * [Michael Lawrence](https://github.com/lawremi)
   * [Uwe Ligges](https://www.statistik.tu-dortmund.de/~ligges/)

--- a/12-R_Core_Developers.Rmd
+++ b/12-R_Core_Developers.Rmd
@@ -4,24 +4,24 @@ This page lists the former and current members of the R Core team who have write
 
 Current members of the R Core team:
 
-  * John Chambers
-  * Peter Dalgaard
-  * Robert Gentleman
-  * Kurt Hornik
-  * Ross Ihaka
-  * Tomas Kalibera
-  * Michael Lawrence
-  * Uwe Ligges
-  * Thomas Lumley
-  * Martin Maechler
-  * Sebastian Meyer
-  * Paul Murrell
-  * Martyn Plummer
-  * Brian Ripley
-  * Deepayan Sarkar
-  * Duncan Temple Lang
-  * Luke Tierney
-  * Simon Urbanek
+  * [John Chambers](https://datascience.stanford.edu/people/john-chambers)
+  * [Peter Dalgaard](www.cbs.dk/en/staff/pdmes)
+  * [Robert Gentleman](https://en.wikipedia.org/wiki/Robert_Gentleman_(statistician))
+  * [Kurt Hornik](https://statmath.wu.ac.at/~hornik/software.html)
+  * [Ross Ihaka](https://www.researchgate.net/profile/Ross-Ihaka)
+  * [Tomas Kalibera](https://github.com/kalibera)
+  * [Michael Lawrence](https://github.com/lawremi)
+  * [Uwe Ligges](https://www.statistik.tu-dortmund.de/~ligges/)
+  * [Thomas Lumley](https://github.com/tslumley)
+  * [Martin Maechler](https://people.math.ethz.ch/~maechler/)
+  * [Sebastian Meyer](https://www.imbe.med.fau.de/lehrstuhl/sebastian-meyer/)
+  * [Paul Murrell](https://www.stat.auckland.ac.nz/~paul/)
+  * [Martyn Plummer](https://warwick.ac.uk/fac/sci/statistics/staff/academic-research/plummer/)
+  * [Brian Ripley](https://www.stats.ox.ac.uk/~ripley/)
+  * [Deepayan Sarkar](https://www.isid.ac.in/~deepayan/)
+  * [Duncan Temple Lang](https://www.stat.ucdavis.edu/~duncan/)
+  * [Luke Tierney](https://stat.uiowa.edu/people/luke-tierney)
+  * [Simon Urbanek](https://urbanek.info/)
 
 Former members of the R Core team:
 
@@ -33,8 +33,5 @@ Former members of the R Core team:
   * Stefano lacus (up to July 2014)
   * Guido Masarotto (up to June 2003)
   * Heiner Schwarte (up to October 1999)
-
-We've left it up to the individual core developers to list areas of expertise (or things they are willing to maintain) if they wish.
-<!-- TODO add URL to bios, perhaps on the R project website -->
 
 The [Contributors page on the R Project website](https://www.r-project.org/contributors.html) also lists contributors, outside the R Core team, who provided invaluable help by donating code, bug fixes, and documentation.

--- a/12-R_Core_Developers.Rmd
+++ b/12-R_Core_Developers.Rmd
@@ -2,34 +2,39 @@
 
 This page lists the former and current members of the R Core team who have write access to the R source.
 
-  * Brian Ripley (present) 
-  * Deepayan Sarkar (present) 
-  * Douglas Bates (present) 
+Current members of the R Core team:
+
+  * John Chambers
+  * Peter Dalgaard
+  * Robert Gentleman
+  * Kurt Hornik
+  * Ross Ihaka
+  * Tomas Kalibera
+  * Michael Lawrence
+  * Uwe Ligges
+  * Thomas Lumley
+  * Martin Maechler
+  * Sebastian Meyer
+  * Paul Murrell
+  * Martyn Plummer
+  * Brian Ripley
+  * Deepayan Sarkar
+  * Duncan Temple Lang
+  * Luke Tierney
+  * Simon Urbanek
+
+Former members of the R Core team:
+
+  * Friedrich Leisch (up to April 2024)
+  * Douglas Bates (up to March 2024)
+  * Martin Morgan (up to June 2021)
   * Duncan Murdoch (up to September 2017)
-  * Duncan Temple Lang (present) 
-  * Friedrich Leisch (present)
+  * Seth Falcon (up to August 2015)
+  * Stefano lacus (up to July 2014)
   * Guido Masarotto (up to June 2003)
   * Heiner Schwarte (up to October 1999)
-  * John Chambers (present)
-  * Kurt Hornik (present)
-  * Luke Tierney (present)
-  * Martin Maechler (present)
-  * Sebastian Meyer (present)
-  * Martin Morgan (up to June 2021)
-  * Martyn Plummer (present)
-  * Michael Lawrence (present)
-  * Paul Murrell (present)
-  * Peter Dalgaard (present)
-  * Robert Gentleman (present)
-  * Ross Ihaka (present)
-  * Seth Falcon (up to August 2015)
-  * Simon Urbanek (present)
-  * Stefano lacus (up to July 2014)
-  * Thomas Lumley (present)
-  * Tomas Kalibera (present)
-  * Uwe Ligges (present)
 
-View the [affiliations of R Core members](). We've left it up to the individual core developers to list areas of expertise (or things they are willing to maintain) if they wish.
+We've left it up to the individual core developers to list areas of expertise (or things they are willing to maintain) if they wish.
 <!-- TODO add URL to bios, perhaps on the R project website -->
 
 The [Contributors page on the R Project website](https://www.r-project.org/contributors.html) also lists contributors, outside the R Core team, who provided invaluable help by donating code, bug fixes, and documentation.


### PR DESCRIPTION
## Overview

Resolves #214 by:

- Splitting the R Core team into present and former lists
- Updating the lists to represent the changes from 2024
- Removing the affiliations link / sentence

## Question

This sentence 

> 'We've left it up to the individual core developers to list areas of expertise (or things they are willing to maintain) if they wish.' 

Feels a bit of out place still as I can't see anything listed on areas of expertise? Is there something we should be adding here, or should we remove that sentence?