### PR TITLE
Improve internal linking: add chapter anchors and fix references

### DIFF
--- a/chapters/additional_resources.qmd
+++ b/chapters/additional_resources.qmd
@@ -1,4 +1,4 @@
-# Additional resources {#AdditionalResources}
+# Additional resources {#sec-additional-resources}
 
 There are a number of further resources to help with contributions to R.
 

--- a/chapters/developer_tools.qmd
+++ b/chapters/developer_tools.qmd
@@ -1,4 +1,4 @@
-# Developer Tools {#DevTools}
+# Developer Tools {#sec-dev-tools}
 
 This chapter lists resources and tools which R developers may use. Here we will go over some commonly used tools that are relevant to R’s workflow. As there are several ways to accomplish these tasks, this chapter reflects methods suitable for new contributors. Experienced contributors may desire a different approach.
 

--- a/chapters/documenting.qmd
+++ b/chapters/documenting.qmd
@@ -1,4 +1,4 @@
-# Documenting {#Doc}
+# Documenting {#sec-doc}
 
 R has a substantial body of documentation, comprising help files for the core packages and a set of manuals aimed at users (An Introduction to R, R Data Import/Export), system administrators (R Installation and Administration) and developers (Writing R Extensions, The R language definition, and R Internals). This documentation was developed by the R Core Team with input from external contributors. The continuing involvement of the user community is important in maintaining this valuable documentation.
 

--- a/chapters/finding_the_source.qmd
+++ b/chapters/finding_the_source.qmd
@@ -1,4 +1,4 @@
-# Finding the Source {#FindSource}
+# Finding the Source {#sec-find-source}
 
 This chapter discusses how you can have an overview of the R codebase. For instance, where to find the implementation of a base function written in R and where to find a primitive implementation written in C. You may want to find the source code of a function just out of curiosity or maybe to gain more insight into what a particular function is actually doing. Whatever be the case, reading the source code will help you to learn a lot about any function.
 
@@ -31,7 +31,7 @@ but this does not include `-` so you can search for a function or S3 method as f
 "quantile.ecdf <- function" extension:R
 ```
 
-  * Search in the R sources using grep: The [R Patched and Development Versions](#GetStart) chapter discusses how to download the R sources directly or from the svn repository. Now if the sources are in `~/R-devel`, you can search as follows:
+  * Search in the R sources using grep: The [R Patched and Development Versions](#sec-get-start) chapter discusses how to download the R sources directly or from the svn repository. Now if the sources are in `~/R-devel`, you can search as follows:
   
 ```  
 grep -R "body <- function" ~/R-devel/src

--- a/chapters/getting_started.qmd
+++ b/chapters/getting_started.qmd
@@ -1,4 +1,4 @@
-# R Patched and Development Versions {#GetStart}
+# R Patched and Development Versions {#sec-get-start}
 
 These instructions cover how to install R from source or from binaries.
 Contributors will typically need to work with the patched or development versions of R.
@@ -141,7 +141,7 @@ make check
 ```
 
 Once you successfully built R from source you can modify the R source code to fix an issue: Prepare a patch (See [this guide](https://www.r-project.org/bugs.html#how-to-submit-patches)) and after checking that R works as intended (`make check-devel`) submit the patch for consideration by R Core.
-(See the [lifecycle of a patch](#FixBug) chapter).
+(See the [lifecycle of a patch](#sec-fix-bug) chapter).
 
 
 To use the `r-devel` version in RStudio, you can do the following:

--- a/chapters/getting_started.qmd
+++ b/chapters/getting_started.qmd
@@ -141,7 +141,7 @@ make check
 ```
 
 Once you successfully built R from source you can modify the R source code to fix an issue: Prepare a patch (See [this guide](https://www.r-project.org/bugs.html#how-to-submit-patches)) and after checking that R works as intended (`make check-devel`) submit the patch for consideration by R Core.
-(See the [lifecycle of a patch](#sec-fix-bug) chapter).
+(See the [lifecycle of a patch](#sec-lifecycle-of-a-patch) chapter).
 
 
 To use the `r-devel` version in RStudio, you can do the following:

--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -7,7 +7,7 @@ This guide is a comprehensive resource for contributing to base R^[The [set of p
 Contributions to base R are possible in a number of different ways. Some of them are listed below:
 
 1. Contributing to bug fixing: Refer to [Issue Tracking](#IssueTrack) and [Reviewing Bugs](#ReviewBugs).
-2. Contributing to translations: Refer to [Translations](#message-translations).
+2. Contributing to translations: Refer to [Translations](#MessageTranslations).
 3. Testing R before release: Refer to [Testing Pre-release R Versions](#TestRVer).
 4. Contributing to documentation, including this guide: Refer to [Documenting R](#Doc) and [Contributing to this guide](#how-to-contribute-to-this-guide).
 

--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -6,9 +6,9 @@ This guide is a comprehensive resource for contributing to base R^[The [set of p
 
 Contributions to base R are possible in a number of different ways. Some of them are listed below:
 
-1. Contributing to bug fixing: Refer to [Issue Tracking](#sec-issue-track) and [Reviewing Bugs](#sec-review-bugs).
+1. Contributing to bug fixing: Refer to [Issue Tracking](#sec-issue-tracking) and [Reviewing Bugs](#sec-reviewing-bugs).
 2. Contributing to translations: Refer to [Message Translations](#sec-message-translations).
-3. Testing R before release: Refer to [Testing Pre-release R Versions](#sec-test-Rver).
+3. Testing R before release: Refer to [Testing Pre-release R Versions](#sec-testing-pre-releases).
 4. Contributing to documentation, including this guide: Refer to [Documenting R](#sec-doc) and [Contributing to this guide](#how-to-contribute-to-this-guide).
 
 <!-- TODO(Saranjeet): Welcome to Bug BBQ slides -->
@@ -28,7 +28,7 @@ The guide is intended as a comprehensive resource for contributing to base R. Th
 
 - The [Submitting Feature Requests](#sec-feature-requests) chapter discusses how to submit feature requests and shares some examples submitted to Bugzilla.
 
-- The [Reviewing Bugs](#sec-review-bugs) chapter discusses how you can make a contribution to reviewing bug reports.
+- The [Reviewing Bugs](#sec-reviewing-bugs) chapter discusses how you can make a contribution to reviewing bug reports.
 
 - The [Finding the Source](#sec-find-source) chapter provides an overview of the R codebase and helps with finding source code of base functions written in R and/or C.
 
@@ -38,7 +38,7 @@ The guide is intended as a comprehensive resource for contributing to base R. Th
 
 - The [Message Translations](#sec-message-translations) chapter covers internationalization in R, i.e., the display of messages in languages other than English.
 
-- The [Testing Pre-release R Versions](#sec-test-Rver) chapter discusses how you can help with testing of pre-release versions of R.
+- The [Testing Pre-release R Versions](#sec-testing-pre-releases) chapter discusses how you can help with testing of pre-release versions of R.
 
 - For more information on how to engage with the community and ask for help, refer to the [Where to Get Help](#sec-where-to-get-help) chapter.
 

--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -1,15 +1,15 @@
-# Introduction
+# Introduction {sec-introduction}
 
-This guide is a comprehensive resource for contributing to base R^[The [set of packages](https://cran.r-project.org/doc/FAQ/R-FAQ.html#Add_002don-packages-in-R) in the base R distribution that are maintained by the R Core Team.] – for both new and experienced contributors. It is maintained by the [R Contribution Working Group](/working-group). We welcome your contributions to base R!
+This guide is a comprehensive resource for contributing to base R^[The [set of packages](https://cran.r-project.org/doc/FAQ/R-FAQ.html#Add_002don-packages-in-R) in the base R distribution that are maintained by the R Core Team.] – for both new and experienced contributors. It is maintained by the [R Contribution Working Group](https://contributor.r-project.org/working-group). We welcome your contributions to base R!
 
 ## Overview of different ways of contributing to the base R Project
 
 Contributions to base R are possible in a number of different ways. Some of them are listed below:
 
-1. Contributing to bug fixing: Refer to [Issue Tracking](#IssueTrack) and [Reviewing Bugs](#ReviewBugs).
-2. Contributing to translations: Refer to [Translations](#MessageTranslations).
-3. Testing R before release: Refer to [Testing Pre-release R Versions](#TestRVer).
-4. Contributing to documentation, including this guide: Refer to [Documenting R](#Doc) and [Contributing to this guide](#how-to-contribute-to-this-guide).
+1. Contributing to bug fixing: Refer to [Issue Tracking](#sec-issue-track) and [Reviewing Bugs](#sec-review-bugs).
+2. Contributing to translations: Refer to [Translations](#sec-message-translations).
+3. Testing R before release: Refer to [Testing Pre-release R Versions](#sec-test-Rver).
+4. Contributing to documentation, including this guide: Refer to [Documenting R](#sec-doc) and [Contributing to this guide](#how-to-contribute-to-this-guide).
 
 <!-- TODO(Saranjeet): Welcome to Bug BBQ slides -->
 <!-- TODO(Saranjeet): README on Bug BBQ repo -->
@@ -18,37 +18,37 @@ Contributions to base R are possible in a number of different ways. Some of them
 
 The guide is intended as a comprehensive resource for contributing to base R. The following chapter outline provides an overview with links to sections for getting started with contributing.
 
-- The [Introduction](#Introduction) chapter provides an overview of different ways of contributing to the R project, a quick start to the guide, and a section on how to contribute to the guide itself.
+- The [Introduction](#sec-introduction) chapter provides an overview of different ways of contributing to the R project, a quick start to the guide, and a section on how to contribute to the guide itself.
 
-- The [R Patched and Development Versions](#GetStart) chapter covers instructions on how to install R from source or from binaries and also discusses the tools required to build R. 
+- The [R Patched and Development Versions](#sec-get-start) chapter covers instructions on how to install R from source or from binaries and also discusses the tools required to build R. 
 
-- The [Issue Tracking](#IssueTrack) chapter covers how contributors can support issue tracking in R, how to get an account on R's Bugzilla, how to navigate Bugzilla and search for bugs to contribute to.
+- The [Issue Tracking](#sec-issue-tracking) chapter covers how contributors can support issue tracking in R, how to get an account on R's Bugzilla, how to navigate Bugzilla and search for bugs to contribute to.
 
-- The [Reporting Bugs](#ReportingBugs) chapter discusses what condition may or may not be a bug and how to report bugs if you find them.
+- The [Reporting Bugs](#sec-reporting-bugs) chapter discusses what condition may or may not be a bug and how to report bugs if you find them.
 
-- The [Submitting Feature Requests](#FeatureRequests) chapter discusses how to submit feature requests and shares some examples submitted to Bugzilla.
+- The [Submitting Feature Requests](#sec-feature-requests) chapter discusses how to submit feature requests and shares some examples submitted to Bugzilla.
 
-- The [Reviewing Bugs](#ReviewBugs) chapter discusses how you can make a contribution to reviewing bug reports.
+- The [Reviewing Bugs](#sec-review-bugs) chapter discusses how you can make a contribution to reviewing bug reports.
 
-- The [Finding the Source](#FindSource) chapter provides an overview of the R codebase and helps with finding source code of base functions written in R and/or C.
+- The [Finding the Source](#sec-find-source) chapter provides an overview of the R codebase and helps with finding source code of base functions written in R and/or C.
 
-- The [Lifecycle of a Patch](#FixBug) chapter discusses how to create a patch to propose a bug fix.
+- The [Lifecycle of a Patch](#sec-fix-bug) chapter discusses how to create a patch to propose a bug fix.
 
-- The [Documenting](#Doc) chapter describes the format and style guide for help files in R, how to report and review issues in the existing documentation, and how to propose changes.
+- The [Documenting](#sec-doc) chapter describes the format and style guide for help files in R, how to report and review issues in the existing documentation, and how to propose changes.
 
-- The [Message Translations](#MessageTranslations) chapter covers internationalization in R, i.e., the display of messages in languages other than English.
+- The [Message Translations](#sec-message-translations) chapter covers internationalization in R, i.e., the display of messages in languages other than English.
 
-- The [Testing Pre-release R Versions](#TestRVer) chapter discusses how you can help with testing of pre-release versions of R.
+- The [Testing Pre-release R Versions](#sec-test-Rver) chapter discusses how you can help with testing of pre-release versions of R.
 
-- For more information on how to engage with the community and ask for help, refer to the [Where to Get Help](#WhereToGetHelp) chapter.
+- For more information on how to engage with the community and ask for help, refer to the [Where to Get Help](#sec-where-to-get-help) chapter.
 
-- To keep up with the developments in R refer to the resources available in the [News and Announcements](#News) chapter.
+- To keep up with the developments in R refer to the resources available in the [News and Announcements](#sec-news) chapter.
 
-- Tools that may be useful for R developers are available in the [Developer Tools](#DevTools) chapter.
+- Tools that may be useful for R developers are available in the [Developer Tools](#sec-dev-tools) chapter.
 
-- Additional resources for contributing to R are available in the [Additional Resources](#AdditionalResources) chapter.
+- Additional resources for contributing to R are available in the [Additional Resources](#sec-additional-resources) chapter.
 
-- The [R Core Developers](#CoreDev) chapter contains a list of the former and current members of the R Core Team who have write access to the R source.
+- The [R Core Developers](#sec-core-dev) chapter contains a list of the former and current members of the R Core Team who have write access to the R source.
 
 ## How to contribute to this guide itself? {#how-to-contribute-to-this-guide}
 

--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -7,7 +7,7 @@ This guide is a comprehensive resource for contributing to base R^[The [set of p
 Contributions to base R are possible in a number of different ways. Some of them are listed below:
 
 1. Contributing to bug fixing: Refer to [Issue Tracking](#sec-issue-track) and [Reviewing Bugs](#sec-review-bugs).
-2. Contributing to translations: Refer to [Translations](#sec-message-translations).
+2. Contributing to translations: Refer to [Message Translations](#sec-message-translations).
 3. Testing R before release: Refer to [Testing Pre-release R Versions](#sec-test-Rver).
 4. Contributing to documentation, including this guide: Refer to [Documenting R](#sec-doc) and [Contributing to this guide](#how-to-contribute-to-this-guide).
 
@@ -32,7 +32,7 @@ The guide is intended as a comprehensive resource for contributing to base R. Th
 
 - The [Finding the Source](#sec-find-source) chapter provides an overview of the R codebase and helps with finding source code of base functions written in R and/or C.
 
-- The [Lifecycle of a Patch](#sec-fix-bug) chapter discusses how to create a patch to propose a bug fix.
+- The [Lifecycle of a Patch](#sec-lifecycle-of-a-patch) chapter discusses how to create a patch to propose a bug fix.
 
 - The [Documenting](#sec-doc) chapter describes the format and style guide for help files in R, how to report and review issues in the existing documentation, and how to propose changes.
 

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -1,4 +1,4 @@
-# Issue Tracking {#sec-issue-track}
+# Issue Tracking {#sec-issue-tracking}
 
 Base R uses [Bugzilla](https://bugs.r-project.org/) for issue tracking and reporting bugs. 
 
@@ -8,7 +8,7 @@ Contributors can support issue tracking in R by
 
 1. [Reporting bugs](#sec-reporting-bugs) or [submitting feature requests](#sec-feature-requests) (bug reports filed under the "Wishlist" component in Bugzilla),
 
-2. [Reviewing bug reports](#sec-review-bugs) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
+2. [Reviewing bug reports](#sec-reviewing-bugs) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
 
 3. [Proposing changes](#sec-lifecycle-of-a-patch) to code or documentation that will close an issue. 
 

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -8,9 +8,9 @@ Contributors can support issue tracking in R by
 
 1. [Reporting bugs](#sec-reporting-bugs) or [submitting feature requests](#sec-feature-requests) (bug reports filed under the "Wishlist" component in Bugzilla),
 
-2. [Reviewing bug reports](sec-reviewing-bugs) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
+2. [Reviewing bug reports](#sec-review-bugs) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
 
-3. [Proposing changes](sec-fix-bug) to code or documentation that will close an issue. 
+3. [Proposing changes](#sec-lifecycle-of-a-patch) to code or documentation that will close an issue. 
 
 ## How to get a Bugzilla account?  {#bugzilla-account}
 

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -1,4 +1,4 @@
-# Issue Tracking {#IssueTrack}
+# Issue Tracking {#sec-issue-track}
 
 Base R uses [Bugzilla](https://bugs.r-project.org/) for issue tracking and reporting bugs. 
 
@@ -6,11 +6,11 @@ Base R uses [Bugzilla](https://bugs.r-project.org/) for issue tracking and repor
 
 Contributors can support issue tracking in R by
 
-1. [Reporting bugs](#ReportingBugs) or [submitting feature requests](#FeatureRequests) (bug reports filed under the "Wishlist" component in Bugzilla),
+1. [Reporting bugs](#sec-reporting-bugs) or [submitting feature requests](#sec-feature-requests) (bug reports filed under the "Wishlist" component in Bugzilla),
 
-2. [Reviewing bug reports](reviewing_bugs.qmd) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
+2. [Reviewing bug reports](sec-reviewing-bugs) to help close reports where no fix is needed or to help narrow down the problem and identify what needs to be fixed, or
 
-3. [Proposing changes](lifecycle_of_a_patch.qmd) to code or documentation that will close an issue. 
+3. [Proposing changes](sec-fix-bug) to code or documentation that will close an issue. 
 
 ## How to get a Bugzilla account?  {#bugzilla-account}
 

--- a/chapters/lifecycle_of_a_patch.qmd
+++ b/chapters/lifecycle_of_a_patch.qmd
@@ -1,4 +1,4 @@
-# Lifecycle of a Patch {#FixBug}
+# Lifecycle of a Patch {#sec-fix-bug}
 
 ## Introduction
 
@@ -26,7 +26,7 @@ To submit a patch, you need:
   ```
   
   Depending on the operative system you might need to do some steps before that. 
-  The different steps required can be found in previous chapters of the book, for [Windows](#windowsSource), [macOS](#macos) and [Linux](#linux).
+  The different steps required can be found in previous chapters of the book, for [Windows](#windows), [macOS](#macos) and [Linux](#linux).
 
 ## How to prepare a patch?
 
@@ -40,7 +40,7 @@ Then you should check that R still works as expected via:
   make check-devel
   ```
 
-If there is no test for your proposed change you can add a new regression test, following [the guidelines](#TestRVer).
+If there is no test for your proposed change you can add a new regression test, following [the guidelines](#sec-test-Rver).
 
 Then you should bring changes from the repository into the working copy, in case any other change has been introduced, and create a patch.diff file with just the changes you want to propose to the R core:
 
@@ -100,7 +100,7 @@ When creating a patch for submission, there are several things that you can do t
 
 1. Make sure to follow [R's coding standards](https://cran.r-project.org/doc/manuals/r-release/R-ints.html#R-coding-standards) (R is a GNU project and there are GNU coding standards). The coding style of the patch you submit should largely match with the codebase it is being applied to. If your patch has one or two minor discrepancies, then those may be fixed by the core developer who will eventually test your patch. However, if there are systematic deviations from the style guides your patch will be put on hold until you fix the formatting issues. There is no comprehensive official R style manual, however some nearly universal standards are summarised in [this article](https://cran.r-project.org/web/packages/rockchalk/vignettes/Rstyle.pdf).
 
-2. Be aware of backwards-compatibility considerations. While the core developer who eventually handles your patch will make the final call on whether something is acceptable, thinking about backwards-compatibility early will help prevent having your patch rejected on these grounds. Put yourself in the shoes of someone whose code will be broken by the change(s) introduced by the patch. It is quite likely that any change made will break someone's code, so you need to have a good reason to make a change as you will be forcing someone to update their code. This obviously does not apply to new functions or new arguments. New arguments should be optional and have default values which maintain the existing behaviour. If in doubt, [discuss](#WhereToGetHelp) the issue with experienced developers.
+2. Be aware of backwards-compatibility considerations. While the core developer who eventually handles your patch will make the final call on whether something is acceptable, thinking about backwards-compatibility early will help prevent having your patch rejected on these grounds. Put yourself in the shoes of someone whose code will be broken by the change(s) introduced by the patch. It is quite likely that any change made will break someone's code, so you need to have a good reason to make a change as you will be forcing someone to update their code. This obviously does not apply to new functions or new arguments. New arguments should be optional and have default values which maintain the existing behaviour. If in doubt, [discuss](#sec-where-to-get-help) the issue with experienced developers.
 
 3. Make sure you have proper tests to verify that your patch works as expected. Patches may not be accepted without the proper tests.
 

--- a/chapters/lifecycle_of_a_patch.qmd
+++ b/chapters/lifecycle_of_a_patch.qmd
@@ -1,4 +1,4 @@
-# Lifecycle of a Patch {#sec-fix-bug}
+# Lifecycle of a Patch {#sec-lifecycle-of-a-patch}
 
 ## Introduction
 

--- a/chapters/lifecycle_of_a_patch.qmd
+++ b/chapters/lifecycle_of_a_patch.qmd
@@ -40,7 +40,7 @@ Then you should check that R still works as expected via:
   make check-devel
   ```
 
-If there is no test for your proposed change you can add a new regression test, following [the guidelines](#sec-test-Rver).
+If there is no test for your proposed change you can add a new regression test, following [the guidelines](#sec-testing-pre-releases).
 
 Then you should bring changes from the repository into the working copy, in case any other change has been introduced, and create a patch.diff file with just the changes you want to propose to the R core:
 

--- a/chapters/message_translations.qmd
+++ b/chapters/message_translations.qmd
@@ -4,7 +4,7 @@ editor_options:
     wrap: 72
 ---
 
-# Message Translations
+# Message Translations {#sec-message-translations}
 
 This chapter covers internationalization in R, i.e., the display of
 messages in languages other than English. All output in R (such as

--- a/chapters/news_and_announcements.qmd
+++ b/chapters/news_and_announcements.qmd
@@ -1,4 +1,4 @@
-# News and Announcements {#News}
+# News and Announcements {#sec-news}
 
 Here are some resources that can be useful to keep up with the developments in R:
 

--- a/chapters/r_core_developers.qmd
+++ b/chapters/r_core_developers.qmd
@@ -1,4 +1,4 @@
-# R Core Developers {#CoreDev}
+# R Core Developers {#sec-core-dev}
 
 This page lists the current and former members of the R Core Team who have write access to the R source.
 

--- a/chapters/reporting_bugs.qmd
+++ b/chapters/reporting_bugs.qmd
@@ -1,4 +1,4 @@
-# Reporting Bugs {#ReportingBugs}
+# Reporting Bugs {#sec-reporting-bugs}
 
 ## What is a bug in R?
 

--- a/chapters/reviewing_bugs.qmd
+++ b/chapters/reviewing_bugs.qmd
@@ -1,4 +1,4 @@
-# Reviewing Bugs {#sec-review-bugs}
+# Reviewing Bugs {#sec-reviewing-bugs}
 
 ## How you can help to review bug reports?
 

--- a/chapters/reviewing_bugs.qmd
+++ b/chapters/reviewing_bugs.qmd
@@ -1,4 +1,4 @@
-# Reviewing Bugs {#ReviewBugs}
+# Reviewing Bugs {#sec-review-bugs}
 
 ## How you can help to review bug reports?
 

--- a/chapters/submitting_feature_requests.qmd
+++ b/chapters/submitting_feature_requests.qmd
@@ -1,4 +1,4 @@
-# Submitting Feature Requests {#FeatureRequests}
+# Submitting Feature Requests {#sec-feature-requests}
 
 ## What is a feature request?
 

--- a/chapters/testing_pre_release_r_versions.qmd
+++ b/chapters/testing_pre_release_r_versions.qmd
@@ -1,4 +1,4 @@
-# Testing Pre-release R Versions {#TestRVer}
+# Testing Pre-release R Versions {#sec-test-Rver}
 
 This chapter is inspired from the blog on [testing R before release](https://blog.r-project.org/2021/04/28/r-can-use-your-help-testing-r-before-release/index.html) and discusses how you can help with testing of pre-release versions of R. 
 

--- a/chapters/testing_pre_release_r_versions.qmd
+++ b/chapters/testing_pre_release_r_versions.qmd
@@ -1,4 +1,4 @@
-# Testing Pre-release R Versions {#sec-test-Rver}
+# Testing Pre-release R Versions {#sec-testing-pre-releases}
 
 This chapter is inspired from the blog on [testing R before release](https://blog.r-project.org/2021/04/28/r-can-use-your-help-testing-r-before-release/index.html) and discusses how you can help with testing of pre-release versions of R. 
 

--- a/chapters/where_to_get_help.qmd
+++ b/chapters/where_to_get_help.qmd
@@ -1,4 +1,4 @@
-# Where to Get Help {#WhereToGetHelp}
+# Where to Get Help {#sec-where-to-get-help}
 
 If you are working on R it is possible that you will come across an issue where you would need some assistance to solve it. If you require help, there are options available to seek assistance or get some feedback which are discussed in this chapter. If the question involves process or tool usage then please check the rest of this guide first as it should answer your question. Please make sure to search the documentation and resources to see if your question has already been addressed. If not, then ask for assistance in the appropriate forum. Many developers are volunteers and please be polite, patient, and thoughtful when requesting for feedback or help.
 


### PR DESCRIPTION
### Description
- Added anchors of the form {#sec-...} to all chapter headings  
- Updated links in the introduction and elsewhere to point to the new anchors  
- Standardised link text to match the corresponding chapter titles  
- Ran Lychee on the built guide to confirm, and also manually checked the guide for broken links  

This ensures consistent internal navigation, enables cross-references,
and improves maintainability of the R Dev Guide.

## Fixed
Match linked text to resp. chapters/sections