### PR TITLE
Docs: Add rig instructions for R pre-release testing

### DIFF
--- a/chapters/testing_pre_release_r_versions.qmd
+++ b/chapters/testing_pre_release_r_versions.qmd
@@ -10,6 +10,28 @@ Whenever possible use a fresh package library for testing, even better would be 
 
 A free Windows 10 virtual machine is provided by Microsoft (with a 90-day limit) for building, testing, and checking R packages and R itself. Package maintainers who work on Linux and MacOS can use it to test their packages on Windows. Read the [instructions](https://svn.r-project.org/R-dev-web/trunk/WindowsBuilds/winutf8/ucrt3/vm.html) on how to automatically set up the machine to check R packages. Tomas Kalibera describes the details of using virtual machine in the blog [Virtual Windows machine for checking R packages](https://blog.r-project.org/2021/03/18/virtual-windows-machine-for-checking-r-packages/index.html). 
 
+## Installing and Switching Pre-release R Versions
+
+A user-friendly way to manage and install R versions, including the pre-release (alpha) version, is by using the rig tool.
+
+To install the latest development version of R (often called R-next):
+
+```bash
+rig add next
+```
+
+You can run this version directly in your terminal using the alias:
+
+```bash 
+R-next
+```
+
+Alternatively, you can switch it to be the default R version on your system:
+
+```bash
+rig default R-next
+```
+
 ## What can you test?
 
 You can test:


### PR DESCRIPTION
Incorporates suggestion from **Issue #239** to document the use of 'rig add next' and 'R-next' for installing and switching to the development version of R.

### Summary

Adds a new section to the **Testing Pre-release R Versions** chapter (`testing_pre_release_r_versions.qmd`) detailing the user-friendly commands for managing R's development version using the **rig** tool.

- [x] Added a section for `rig add next`, `R-next`, and `rig default R-next`.
- [x] Ensured commands are correctly formatted in `bash` code blocks.

Fixes #239

### Checklist for adding a new chapter or chapters

### What should a reviewer concentrate their feedback on?

- [ ] Check the placement and clarity of the new section in the documentation flow.
- [x] Everything looks ok?

### Acknowledging contributors

List any contributions that need adding to the [table of contributors](https://github.com/r-devel/rdevguide/blob/main/README.md#contributors-). Common contributions are `content` (adding to the guide), `doc` (e.g. README, wiki), `infra` (e.g. GitHub action), and `maintenance` (e.g. fixing links). See the full key to [Contribution Types](https://allcontributors.org/docs/en/emoji-key).

- [x] Please add **@hturner** for **idea/content**.
- [ ] **For reviewers**: All relevant contributions have been added, including reviewers, mentors, contributors to the ideas/planning. See [how to acknowledge contributors](https://github.com/r-devel/rdevguide/blob/main/HOWTO-acknowledge-contributors.md).