### PR TITLE
getting_started: correct word order in macOS requirements link

### DIFF
--- a/chapters/getting_started.qmd
+++ b/chapters/getting_started.qmd
@@ -279,7 +279,7 @@ This section will be added after the official [installation instructions for mac
 
 3.  [Tools for R in macOS](https://mac.r-project.org/tools/)
 
-3.  [R for requirements in macOS](https://mac.r-project.org/src/)
+3.  [Requirements for R in macOS](https://mac.r-project.org/src/)
 
 3.  [R for Windows FAQ](https://cran.r-project.org/bin/windows/base/rw-FAQ.html)
 


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. -->

"R for requirements in macOS" should be "Requirements for R in macOS"

- [x] Everything looks ok?

### Acknowledging contributors

List any contributions that need adding to the [table of contributors](https://github.com/r-devel/rdevguide/blob/main/README.md#contributors-). Common contributions are `content` (adding to the guide), `doc` (e.g. README, wiki), `infra` (e.g. GitHub action), and `maintenance` (e.g. fixing links). See the full key to [Contribution Types](https://allcontributors.org/docs/en/emoji-key).

- [x] **For reviewers**: All relevant contributions have been added, including reviewers, mentors, contributors to the ideas/planning. See [how to acknowledge contributors](https://github.com/r-devel/rdevguide/blob/main/HOWTO-acknowledge-contributors.md).