### PR TITLE
docs: add info on R manuals and Texinfo format (#156)

### DIFF
--- a/chapters/documenting.qmd
+++ b/chapters/documenting.qmd
@@ -170,7 +170,7 @@ While R help files use the `.Rd` format, the official R manuals are written in [
 
 * **Editing:** Since `.texi` files are plain text, you can edit them with any text editor.
 * **Compiling:** To see how your changes look, you can "compile" them into PDF or HTML using tools like `makeinfo` or `texi2any` (both part of the GNU Texinfo distribution).
-* **Source:** You can find the source files for these manuals in the [doc/manual directory of the R project SVN](https://github.com/r-devel/r-svn/tree/master/doc/manual).
+* **Source:** You can find the source files for these manuals in the `doc/manual` directory of the R source code.
 
 Improvements can be suggested via the R-devel mailing list or the bug tracker even without a formal patch.
 


### PR DESCRIPTION
### Summary

I've added information to clarify that R manuals use the GNU Texinfo format. I also included links to the Texinfo tools and the SVN source directory as expected by @llrs.

Fixes #156 


### Acknowledging contributors

[x] Please add @kushjchhajed15-creator for content.

