### PR TITLE
Add note about enabling source repos on Ubuntu 24.04+

### DIFF
--- a/chapters/getting_started.qmd
+++ b/chapters/getting_started.qmd
@@ -43,6 +43,8 @@ apt-rdepends --build-depends --follow=DEPENDS r-base-dev | grep " B" | sed -e "s
 
 It might require installation of apt-rdepends which can be done from default repositories via `sudo apt-get install apt-rdepends`.
 
+On Ubuntu Noble (24.04) and later, you may need to enable source repositories first. Edit `/etc/apt/sources.list.d/ubuntu.sources` and change `Types: deb` to `Types: deb deb-src`, then run `sudo apt update`.
+
 To install all the R dependencies you can use:
 
 ```sh

--- a/chapters/getting_started.qmd
+++ b/chapters/getting_started.qmd
@@ -43,7 +43,7 @@ apt-rdepends --build-depends --follow=DEPENDS r-base-dev | grep " B" | sed -e "s
 
 It might require installation of apt-rdepends which can be done from default repositories via `sudo apt-get install apt-rdepends`.
 
-On Ubuntu Noble (24.04) and later, you may need to enable source repositories first. Edit `/etc/apt/sources.list.d/ubuntu.sources` and change `Types: deb` to `Types: deb deb-src`, then run `sudo apt update`.
+On Ubuntu Noble (24.04) and later, you may need to enable source repositories first. If you see the error `You must put some 'deb-src' URIs in your sources.list`, edit `/etc/apt/sources.list.d/ubuntu.sources` and change `Types: deb` to `Types: deb deb-src`, then run `sudo apt update`.
 
 To install all the R dependencies you can use:
 


### PR DESCRIPTION
### Summary

On Ubuntu Noble and later, source repositories are not enabled by default. Users need to edit /etc/apt/sources.list.d/ubuntu.sources to add deb-src before apt-rdepends and build-dep commands will work.  Instructions added in this PR.

Fixes #261 

### What should a reviewer concentrate their feedback on?

- [ ] Everything looks ok?
