### PR TITLE
Fix the Missing alt text 

### DIFF
--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -58,6 +58,7 @@ Maintainers and contributors are also requested to follow [this guide's code of 
 
 This guide is built using Quarto which makes editing it easier, provided you have a GitHub account (sign-up at [github.com](https://github.com/)). After you log-in to GitHub, click on the ‘Edit this page’ (available in the left side column) link highlighted with a red ellipse in the image below. This will take you to an editable version of the source R Markdown file that generated the page you are on:
 
-![Screenshot of the toolbar in the HTML version of the guide, with the "Edit this page" link highlighted in red.](../img/edit_icon.png)
+<img src="../img/edit_icon.png" alt="Screenshot of the toolbar in the HTML version of the guide, with the &quot;Edit this page&quot; link highlighted in red.">
+
 
 Use the [issue tracker](https://github.com/r-devel/rdevguide/issues) to raise an issue about the guide’s content or to make a feature request.

--- a/chapters/introduction.qmd
+++ b/chapters/introduction.qmd
@@ -58,7 +58,6 @@ Maintainers and contributors are also requested to follow [this guide's code of 
 
 This guide is built using Quarto which makes editing it easier, provided you have a GitHub account (sign-up at [github.com](https://github.com/)). After you log-in to GitHub, click on the ‘Edit this page’ (available in the left side column) link highlighted with a red ellipse in the image below. This will take you to an editable version of the source R Markdown file that generated the page you are on:
 
-<img src="../img/edit_icon.png" alt="Screenshot of the toolbar in the HTML version of the guide, with the &quot;Edit this page&quot; link highlighted in red.">
-
+![Screenshot of the toolbar in the HTML version of the guide, with the "Edit this page" link highlighted in red.](../img/edit_icon.png)\
 
 Use the [issue tracker](https://github.com/r-devel/rdevguide/issues) to raise an issue about the guide’s content or to make a feature request.

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -22,11 +22,12 @@ To get a Bugzilla account send an e-mail to `bug-report-request@r-project.org` f
 
 An image of the existing home page of Bugzilla is shared below:
 
-![Screenshot of the existing home page of Bugzilla.](../img/bugzilla.png)
+<img src="../img/bugzilla.png" alt="Screenshot of the existing home page of Bugzilla.">
+
 
 On the home page of Bugzilla, there are various buttons and links. There are four square buttons called as:
 
-![Screenshot of the four square buttons on the home page of Bugzilla.](../img/squarebuttons.png)
+<img src="../img/squarebuttons.png" alt="Screenshot of the four square buttons on the home page of Bugzilla.">
 
 1. [File a bug](https://bugs.r-project.org/enter_bug.cgi): You will have to log in to Bugzilla to file a bug using this button
 
@@ -46,18 +47,18 @@ Several useful shortcuts are available from the landing page:
 
 A [quick search](https://bugs.r-project.org/page.cgi?id=quicksearch.html) bar is available on the home page where you can enter a bug number to search or some search terms.
 
-![Screenshot of the quick search bar on the home page of Bugzilla.](../img/quicksearch.png)
+<img src="../img/quicksearch.png" alt="Screenshot of the quick search bar on the home page of Bugzilla.">
 
 There is also a section for Common Queries on the home page which includes links to bugs reported and changed in the last 24 hours and last 7 days.
 
-![Screenshot of the Common Queries section on the home page of Bugzilla.](../img/commonquery.png)
+<img src="../img/commonquery.png" alt="Screenshot of the Common Queries section on the home page of Bugzilla.">
 
 ## Searching for Bugs to Contribute to {#searching}
 
 When presented with a long list of bugs, it can often be a bit demotivating when it's not clear where to start.
 To help with this, you can use the [**Advanced Search**](https://bugs.r-project.org/query.cgi?format=advanced).
 
-![Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution](../img/bugzilla-adv-search-home.png)
+<img src="../img/bugzilla-adv-search-home.png" alt="Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution">
 
 This presents several fields that you can use to narrow down your search.
 You can find out what a particular field is by clicking on the header, which will take you to that section in the [**Bug Fields Information Page**](https://bugs.r-project.org/page.cgi?id=fields.html).
@@ -93,14 +94,15 @@ You can use this section to narrow down your search further to filter by things 
 
 It can be helpful, for example, to search for bugs labelled with `HELPWANTED`, which indicates bugs that may be suitable for anyone to work on regardless of expertise.
 
-![Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS](../img/bugzilla-adv-search-detailed-bug-info.png)
+<img src="../img/bugzilla-adv-search-detailed-bug-info.png" alt="Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS">
+
 
 
 ### Search By People {#searching-sbp}
 
 You can use this to narrow down your search to only include results of a specific person or up to three people who have participated in any component of the bug's discussion.
 
-![Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter](../img/bugzilla-adv-search-search-by-people.png)
+<img src="../img/bugzilla-adv-search-search-by-people.png" alt="Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter">
 
 
 ### Search By Change History {#searching-sbch}
@@ -108,4 +110,4 @@ You can use this to narrow down your search to only include results of a specifi
 Use this to search for bugs where any of the status fields has been changed (which, depending on the change, could indicate that someone from R-Core has given some attention to the bug).
 This also provides a date range to narrow your search.
 
-![Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)](../img/bugzilla-adv-search-search-by-change-history.png)
+<img src="../img/bugzilla-adv-search-search-by-change-history.png" alt="Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)">

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -22,12 +22,13 @@ To get a Bugzilla account send an e-mail to `bug-report-request@r-project.org` f
 
 An image of the existing home page of Bugzilla is shared below:
 
-<img src="../img/bugzilla.png" alt="Screenshot of the existing home page of Bugzilla.">
+<img src="../img/bugzilla.png" alt="Screenshot of the existing home page of Bugzilla." height="400px" width="550px">
+
 
 
 On the home page of Bugzilla, there are various buttons and links. There are four square buttons called as:
 
-<img src="../img/squarebuttons.png" alt="Screenshot of the four square buttons on the home page of Bugzilla.">
+<img src="../img/squarebuttons.png" alt="Screenshot of the four square buttons on the home page of Bugzilla." height="400px" width="550px">
 
 1. [File a bug](https://bugs.r-project.org/enter_bug.cgi): You will have to log in to Bugzilla to file a bug using this button
 
@@ -47,18 +48,18 @@ Several useful shortcuts are available from the landing page:
 
 A [quick search](https://bugs.r-project.org/page.cgi?id=quicksearch.html) bar is available on the home page where you can enter a bug number to search or some search terms.
 
-<img src="../img/quicksearch.png" alt="Screenshot of the quick search bar on the home page of Bugzilla.">
+<img src="../img/quicksearch.png" alt="Screenshot of the quick search bar on the home page of Bugzilla." height="70px" width="550px">
 
 There is also a section for Common Queries on the home page which includes links to bugs reported and changed in the last 24 hours and last 7 days.
 
-<img src="../img/commonquery.png" alt="Screenshot of the Common Queries section on the home page of Bugzilla.">
+<img src="../img/commonquery.png" alt="Screenshot of the Common Queries section on the home page of Bugzilla." height="147px" width="550px">
 
 ## Searching for Bugs to Contribute to {#searching}
 
 When presented with a long list of bugs, it can often be a bit demotivating when it's not clear where to start.
 To help with this, you can use the [**Advanced Search**](https://bugs.r-project.org/query.cgi?format=advanced).
 
-<img src="../img/bugzilla-adv-search-home.png" alt="Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution">
+<img src="../img/bugzilla-adv-search-home.png" alt="Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution" height="400px" width="5
 
 This presents several fields that you can use to narrow down your search.
 You can find out what a particular field is by clicking on the header, which will take you to that section in the [**Bug Fields Information Page**](https://bugs.r-project.org/page.cgi?id=fields.html).
@@ -94,15 +95,14 @@ You can use this section to narrow down your search further to filter by things 
 
 It can be helpful, for example, to search for bugs labelled with `HELPWANTED`, which indicates bugs that may be suitable for anyone to work on regardless of expertise.
 
-<img src="../img/bugzilla-adv-search-detailed-bug-info.png" alt="Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS">
-
+<img src="../img/bugzilla-adv-search-detailed-bug-info.png" alt="Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS" height="400px" width="550px">
 
 
 ### Search By People {#searching-sbp}
 
 You can use this to narrow down your search to only include results of a specific person or up to three people who have participated in any component of the bug's discussion.
 
-<img src="../img/bugzilla-adv-search-search-by-people.png" alt="Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter">
+<img src="../img/bugzilla-adv-search-search-by-people.png" alt="Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter" height="400px" width="550px">
 
 
 ### Search By Change History {#searching-sbch}
@@ -110,4 +110,5 @@ You can use this to narrow down your search to only include results of a specifi
 Use this to search for bugs where any of the status fields has been changed (which, depending on the change, could indicate that someone from R-Core has given some attention to the bug).
 This also provides a date range to narrow your search.
 
-<img src="../img/bugzilla-adv-search-search-by-change-history.png" alt="Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)">
+<img src="../img/bugzilla-adv-search-search-by-change-history.png" alt="Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)" height="400px" width="550px">
+

--- a/chapters/issue_tracking.qmd
+++ b/chapters/issue_tracking.qmd
@@ -22,13 +22,11 @@ To get a Bugzilla account send an e-mail to `bug-report-request@r-project.org` f
 
 An image of the existing home page of Bugzilla is shared below:
 
-<img src="../img/bugzilla.png" alt="Screenshot of the existing home page of Bugzilla." height="400px" width="550px">
-
-
+![Screenshot of the existing home page of Bugzilla.](../img/bugzilla.png)\
 
 On the home page of Bugzilla, there are various buttons and links. There are four square buttons called as:
 
-<img src="../img/squarebuttons.png" alt="Screenshot of the four square buttons on the home page of Bugzilla." height="400px" width="550px">
+![Screenshot of the four square buttons on the home page of Bugzilla.](../img/squarebuttons.png)\
 
 1. [File a bug](https://bugs.r-project.org/enter_bug.cgi): You will have to log in to Bugzilla to file a bug using this button
 
@@ -48,18 +46,18 @@ Several useful shortcuts are available from the landing page:
 
 A [quick search](https://bugs.r-project.org/page.cgi?id=quicksearch.html) bar is available on the home page where you can enter a bug number to search or some search terms.
 
-<img src="../img/quicksearch.png" alt="Screenshot of the quick search bar on the home page of Bugzilla." height="70px" width="550px">
+![Screenshot of the quick search bar on the home page of Bugzilla.](../img/quicksearch.png)\
 
 There is also a section for Common Queries on the home page which includes links to bugs reported and changed in the last 24 hours and last 7 days.
 
-<img src="../img/commonquery.png" alt="Screenshot of the Common Queries section on the home page of Bugzilla." height="147px" width="550px">
+![Screenshot of the Common Queries section on the home page of Bugzilla.](../img/commonquery.png)\
 
 ## Searching for Bugs to Contribute to {#searching}
 
 When presented with a long list of bugs, it can often be a bit demotivating when it's not clear where to start.
 To help with this, you can use the [**Advanced Search**](https://bugs.r-project.org/query.cgi?format=advanced).
 
-<img src="../img/bugzilla-adv-search-home.png" alt="Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution" height="400px" width="5
+![Screenshot of Advanced Search page showing the following fields: Summary, Product, Component, Status, Resolution](../img/bugzilla-adv-search-home.png)\
 
 This presents several fields that you can use to narrow down your search.
 You can find out what a particular field is by clicking on the header, which will take you to that section in the [**Bug Fields Information Page**](https://bugs.r-project.org/page.cgi?id=fields.html).
@@ -95,14 +93,14 @@ You can use this section to narrow down your search further to filter by things 
 
 It can be helpful, for example, to search for bugs labelled with `HELPWANTED`, which indicates bugs that may be suitable for anyone to work on regardless of expertise.
 
-<img src="../img/bugzilla-adv-search-detailed-bug-info.png" alt="Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS" height="400px" width="550px">
+![Screenshot of expanded Detailed Bug Information section showing the following fields: Comment, URL, Keywords (with HELPWANTED entered), Deadline, inclusion/exclusion of bug numbers, Version, Severity, Priority, Hardware, and OS](../img/bugzilla-adv-search-detailed-bug-info.png)\
 
 
 ### Search By People {#searching-sbp}
 
 You can use this to narrow down your search to only include results of a specific person or up to three people who have participated in any component of the bug's discussion.
 
-<img src="../img/bugzilla-adv-search-search-by-people.png" alt="Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter" height="400px" width="550px">
+![Screenshot of expanded Search By People section showing three fields allowing you to enter a person's name who can be any of the bug assignee, the reporter, a CC list member, or a commenter](../img/bugzilla-adv-search-search-by-people.png)\
 
 
 ### Search By Change History {#searching-sbch}
@@ -110,5 +108,4 @@ You can use this to narrow down your search to only include results of a specifi
 Use this to search for bugs where any of the status fields has been changed (which, depending on the change, could indicate that someone from R-Core has given some attention to the bug).
 This also provides a date range to narrow your search.
 
-<img src="../img/bugzilla-adv-search-search-by-change-history.png" alt="Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)" height="400px" width="550px">
-
+![Screenshot of expanded Search by Change History section showing three fields: where ANY of the fields (multi-select list), changed to, and between (dates in YYYY-MM-DD format)](../img/bugzilla-adv-search-search-by-change-history.png)\

--- a/chapters/message_translations.qmd
+++ b/chapters/message_translations.qmd
@@ -245,7 +245,7 @@ the Windows Graphical User Interface.
 
 After selecting a component, you can select your preferred language.
 
-![](../img/translate_component.png)
+<img src="../img/translate_component.png" alt="Weblate component and language selection screen for R translations." height="400px" width="550px">
 
 <!-- **Step 3: Check String Status** -->
 
@@ -266,12 +266,12 @@ Now, you can click on Translate button on your right.
 > Note: More information for String status visit:
 > <https://docs.weblate.org/en/latest/workflows.html#translation-states>
 
-![](../img/translate_button.png)
+<img src="../img/translate_button.png" alt="Weblate string list showing the Translate button." height="400px" width="550px">
 
 Then, start translating the message by typing the translation in the
 text box.
 
-![](../img/translate_string_and_save.png)
+<img src="../img/translate_string_and_save.png" alt="Weblate translation text box with Save and Continue button." height="400px" width="550px">
 
 -   If you are **confident** that the **translation is correct**, make
     sure the "Needs editing" box is **unchecked**.
@@ -294,7 +294,7 @@ text box.
 
 2.  Accept it if you think the automatic suggestion looks good
 
-![](../img/auto-suggestion.png)
+<img src="../img/auto-suggestion.png" alt="Weblate Automatic Suggestions panel with machine translation suggestions." height="400px" width="550px">
 
 ------------------------------------------------------------------------
 
@@ -326,7 +326,7 @@ Instead of translating one string at a time, it is possible to bulk translate a 
 
 2. Select **'Tools > Automatic translation'**
 
-![Tools drop-down menu with "Automatic Translations" selected](../img/translate_automatic_translation.png)
+<img src="../img/translate_automatic_translation.png" alt="Tools drop-down menu with &quot;Automatic Translations&quot; selected" height="400px" width="550px">
 
 
 3. In the dialog,
@@ -342,7 +342,7 @@ Instead of translating one string at a time, it is possible to bulk translate a 
   
 [^09-message-translations-3]: Microsoft Translator is preferred for bulk translation as our free tier covers 2 million characters/month, where DeepL only allows 500k chars/month. If Microsoft Translator translations are much worse than DeepL, it may be useful to use it to translate one string at a time.
 
-![Automatic Translations dialog box](../img/translate_dialog.png)
+<img src="../img/translate_dialog.png" alt="Automatic Translations dialog box" height="400px" width="550px">
 
 4.  Review the translations, edit as necessary and uncheck **"needing edit"**. 
 

--- a/chapters/message_translations.qmd
+++ b/chapters/message_translations.qmd
@@ -245,7 +245,7 @@ the Windows Graphical User Interface.
 
 After selecting a component, you can select your preferred language.
 
-<img src="../img/translate_component.png" alt="Weblate component and language selection screen for R translations." height="400px" width="550px">
+![](../img/translate_component.png){fig-alt="Weblate component and language selection screen for R translations."}
 
 <!-- **Step 3: Check String Status** -->
 
@@ -266,12 +266,12 @@ Now, you can click on Translate button on your right.
 > Note: More information for String status visit:
 > <https://docs.weblate.org/en/latest/workflows.html#translation-states>
 
-<img src="../img/translate_button.png" alt="Weblate string list showing the Translate button." height="400px" width="550px">
+![](../img/translate_button.png){fig-alt="Weblate string list showing the Translate button."}
 
 Then, start translating the message by typing the translation in the
 text box.
 
-<img src="../img/translate_string_and_save.png" alt="Weblate translation text box with Save and Continue button." height="400px" width="550px">
+![](../img/translate_string_and_save.png){fig-alt="Weblate translation text box with Save and Continue button."}
 
 -   If you are **confident** that the **translation is correct**, make
     sure the "Needs editing" box is **unchecked**.
@@ -294,7 +294,7 @@ text box.
 
 2.  Accept it if you think the automatic suggestion looks good
 
-<img src="../img/auto-suggestion.png" alt="Weblate Automatic Suggestions panel with machine translation suggestions." height="400px" width="550px">
+![](../img/auto-suggestion.png){fig-alt="Weblate Automatic Suggestions panel with machine translation suggestions."}
 
 ------------------------------------------------------------------------
 
@@ -326,7 +326,7 @@ Instead of translating one string at a time, it is possible to bulk translate a 
 
 2. Select **'Tools > Automatic translation'**
 
-<img src="../img/translate_automatic_translation.png" alt="Tools drop-down menu with &quot;Automatic Translations&quot; selected" height="400px" width="550px">
+![Tools drop-down menu with "Automatic Translations" selected](../img/translate_automatic_translation.png)\
 
 
 3. In the dialog,
@@ -342,7 +342,7 @@ Instead of translating one string at a time, it is possible to bulk translate a 
   
 [^09-message-translations-3]: Microsoft Translator is preferred for bulk translation as our free tier covers 2 million characters/month, where DeepL only allows 500k chars/month. If Microsoft Translator translations are much worse than DeepL, it may be useful to use it to translate one string at a time.
 
-<img src="../img/translate_dialog.png" alt="Automatic Translations dialog box" height="400px" width="550px">
+![Automatic Translations dialog box](../img/translate_dialog.png)\
 
 4.  Review the translations, edit as necessary and uncheck **"needing edit"**. 
 

--- a/chapters/submitting_feature_requests.qmd
+++ b/chapters/submitting_feature_requests.qmd
@@ -10,7 +10,7 @@ We recommend sharing your feature request idea on the [R-devel](https://stat.eth
 
 You can submit a feature request by [filing a bug](https://bugs.r-project.org/enter_bug.cgi) on Bugzilla. Under Component, select "Wishlist", the designated label for feature requests.
 
-![The "Wishlist" component in Bugzilla's bug submission screen.](../img/feature-requests.png)
+<img src="../img/feature-requests.png" alt="The &quot;Wishlist&quot; component in Bugzilla's bug submission screen." height="400px" width="550px">
 
 Similar to bugs, you should ensure that the feature request is [not already reported](#already-reported-bugs) and [follow best practices](#good-practices-bugs) whenever possible.
 

--- a/chapters/submitting_feature_requests.qmd
+++ b/chapters/submitting_feature_requests.qmd
@@ -10,7 +10,7 @@ We recommend sharing your feature request idea on the [R-devel](https://stat.eth
 
 You can submit a feature request by [filing a bug](https://bugs.r-project.org/enter_bug.cgi) on Bugzilla. Under Component, select "Wishlist", the designated label for feature requests.
 
-<img src="../img/feature-requests.png" alt="The &quot;Wishlist&quot; component in Bugzilla's bug submission screen." height="400px" width="550px">
+![The "Wishlist" component in Bugzilla's bug submission screen.](../img/feature-requests.png)\
 
 Similar to bugs, you should ensure that the feature request is [not already reported](#already-reported-bugs) and [follow best practices](#good-practices-bugs) whenever possible.
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 # {-}
 
-![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg){height=400px width=550px}
+![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg)\{height=400px width=550px}
 
 # Acknowledgement {-}
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 # {-}
 
-![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg)\{height=400px width=550px}
+![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg){height=400px width=550px}\
 
 # Acknowledgement {-}
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 # {-}
 
-![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg){height=400px width=550px}
+<img src="img/r-dev-guide-without-text.jpg" alt="R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307" height="400px" width="550px">
 
 # Acknowledgement {-}
 
@@ -11,6 +11,8 @@ Initial chapters of the guide were developed by Saranjeet Kaur Bhogal, in a proj
 This guide has benefited and continues to benefit from varied contributions by several [contributors](https://github.com/r-devel/rdevguide#contributors-). 
 
 
-[![License: CC BY 4.0](img/ccby.png)](https://creativecommons.org/licenses/by/4.0/){width=180px}
+<a href="https://creativecommons.org/licenses/by/4.0/" aria-label="This work is licensed under a Creative Commons Attribution 4.0 International License">
+  <img src="img/ccby.png" alt="License: CC BY 4.0" width="180px">
+</a>
 
 This project is licensed under a [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). Some pages may contain materials that are subject to copyright, in which case you will see the copyright notice.

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 # {-}
 
-<img src="img/r-dev-guide-without-text.jpg" alt="R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307" height="400px" width="550px">
+![R Development Guide. This illustration is created by Scriberia with The Turing Way community, used under a CC-BY 4.0 licence. DOI: https://zenodo.org/records/13882307](img/r-dev-guide-without-text.jpg){height=400px width=550px}
 
 # Acknowledgement {-}
 
@@ -11,8 +11,6 @@ Initial chapters of the guide were developed by Saranjeet Kaur Bhogal, in a proj
 This guide has benefited and continues to benefit from varied contributions by several [contributors](https://github.com/r-devel/rdevguide#contributors-). 
 
 
-<a href="https://creativecommons.org/licenses/by/4.0/" aria-label="This work is licensed under a Creative Commons Attribution 4.0 International License">
-  <img src="img/ccby.png" alt="License: CC BY 4.0" width="180px">
-</a>
+[![License: CC BY 4.0](img/ccby.png)](https://creativecommons.org/licenses/by/4.0/){width=180px}\
 
 This project is licensed under a [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). Some pages may contain materials that are subject to copyright, in which case you will see the copyright notice.


### PR DESCRIPTION
Missing alt text on 18 images in issue #273

Problem:
When rendering to HTML, Quarto doesn't convert it into the image's alt attribute. Instead, it turns the image into an implicit figure and moves the description into a visible.

Solution:
To replace the images with raw HTML syntax instead of Markdown image syntax.
